### PR TITLE
API feature: Get minimum/maximum length of a possible match

### DIFF
--- a/regex/src/main/java/com/florianingerl/util/regex/Pattern.java
+++ b/regex/src/main/java/com/florianingerl/util/regex/Pattern.java
@@ -1544,6 +1544,41 @@ public final class Pattern implements java.io.Serializable {
 	private transient boolean hasSupplementary;
 
 	/**
+	 * The TreeInfo of the complete object tree.
+	 */
+	private transient volatile TreeInfo treeInfoRoot;
+
+	private TreeInfo getTreeInfoRoot() {
+		// double checked locking
+		TreeInfo treeInfo = treeInfoRoot;
+		if (treeInfo == null) {
+			synchronized (this) {
+				treeInfo = treeInfoRoot;
+				if (treeInfo == null) {
+					matchRoot.study(treeInfo = new TreeInfo());
+					treeInfoRoot = treeInfo;
+				}
+			}
+		}
+		return treeInfo;
+	}
+
+	/**
+	 * @return The minimum length of a possible match.
+	 */
+	public int getMinLength() {
+		return getTreeInfoRoot().minLength;
+	}
+
+	/**
+	 * @return The maximum length of a possible match or {@link Integer.MAX_VALUE} if there is no maximum.
+	 */
+	public int getMaxLength() {
+		TreeInfo treeInfo = getTreeInfoRoot();
+		return treeInfo.maxValid ? treeInfo.maxLength : Integer.MAX_VALUE;
+	}
+
+	/**
 	 * Compiles the given regular expression into a pattern.
 	 *
 	 * @param regex


### PR DESCRIPTION
I would appreciate this amendment of the API because it can make my code cleaner, i.e. I can do without using reflection for accessing package protected functionality. [Look at my Hack](https://github.com/karalus/WSGenerate/blob/master/src/main/java/com/artofarc/util/RegExHelper.java)

It is also helping to gain better performance in some scenarios:
If you know in advance that a string cannot match the Pattern because it is not matching the minLength/maxLenght, you can go without creating a Matcher-instance saving memory and CPU.